### PR TITLE
feat: data.type 세분화, token재 인증 로직 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4043,7 +4043,8 @@
     "node_modules/@tosspayments/tosspayments-sdk": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@tosspayments/tosspayments-sdk/-/tosspayments-sdk-2.2.4.tgz",
-      "integrity": "sha512-z0U6KGr0/BXLmJDeUH7b64WdDXjBFOWWvAX3PjD7+dzSJUgArLubhiBEx/XwhRre+JXuX9NMAkqS0aPLonDKgQ=="
+      "integrity": "sha512-z0U6KGr0/BXLmJDeUH7b64WdDXjBFOWWvAX3PjD7+dzSJUgArLubhiBEx/XwhRre+JXuX9NMAkqS0aPLonDKgQ==",
+      "license": "MIT"
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",

--- a/src/components/chat/ChatBox.jsx
+++ b/src/components/chat/ChatBox.jsx
@@ -20,7 +20,7 @@ function ChatContainer() {
     if (chatWindowRef.current) {
       chatWindowRef.current.scrollTop = chatWindowRef.current.scrollHeight;
     }
-  }, [messages, userNickname]); // messages 상태가 업데이트될 때마다 실행
+  }, [messages]); // messages 상태가 업데이트될 때마다 실행
 
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {

--- a/src/hooks/useWebSocket.jsx
+++ b/src/hooks/useWebSocket.jsx
@@ -6,16 +6,21 @@ const useWebSocket = (token) => {
     const [isAvailableChat, setAvailableChat] = useState(false);
     const [userNickname, setUserNickname] = useState('');
     const [streamKey, setStreamKey] = useState('');
+ 
     const MAX_MESSAGES = 100;
 
+
     useEffect(() => {
-        if (!token) return;
 
         socket.current = new WebSocket('ws://localhost:8080/ws');
 
         socket.current.onopen = () => {
             console.log('세션 연결 시도');
-            const authMessage = JSON.stringify({ type: 'AUTH', messenger: 'front-server', message: token });
+            const authMessage = JSON.stringify({ 
+                type: 'REQUEST_AUTH', 
+                messenger: 'front-server', 
+                message: token
+            });
             socket.current.send(authMessage);
         };
 
@@ -24,13 +29,54 @@ const useWebSocket = (token) => {
             console.log(data);
             const { type, messenger, message } = data;
 
-            if (type === 'AUTH') {
+            if (type === 'RESPONSE_AUTH') {
                 setUserNickname(messenger);
                 setAvailableChat(true);
 
-                const requestInit = JSON.stringify({ type: 'INIT', messenger: messenger, message: 'Request Initialize' });
+                const requestInit = JSON.stringify({ 
+                    type: 'REQUEST_CHAT_INIT', 
+                    messenger: messenger, 
+                    message: 'Request Initialize' 
+                });
+
                 socket.current.send(requestInit);
-            } else if (type === 'MESSAGE') {
+            }else if(type==='INVALID_TOKEN'){ // 유효하지 않은 토큰 -> 리프레쉬 요청
+                const refreshToken = localStorage.getItem('refreshToken');
+            
+                const requestRefresh = JSON.stringify({
+                    type:'REQUEST_REFRESH',
+                    messenger:"front-server",
+                    message:refreshToken
+                });
+
+                socket.current.send(requestRefresh);
+            } 
+            else if(type==='RESPONSE_REFRESH'){ // Refresh 성공 (refresh가 유효할 경우)
+                const {access,refresh} = JSON.parse(message);
+             
+                localStorage.setItem('accessToken',access);
+                localStorage.setItem('refreshToken',refresh);
+                // Refresh성공으니 다시 AUTH보내기 
+                const authMessage = JSON.stringify({ 
+                    type: 'REQUEST_AUTH', 
+                    messenger: 'front-server', 
+                    message: access
+                });
+                socket.current.send(authMessage);
+                
+            }else if(type==='ANONYMOUS_USER'){ // Refresh도 성공 못하면 익명 유저
+                setAvailableChat(false);
+                
+                // 일단 채팅창은 가능 하도록
+                const requestInit = JSON.stringify({ 
+                    type: 'REQUEST_CHAT_INIT', 
+                    messenger: messenger, 
+                    message: 'Request Initialize' 
+                });
+
+                socket.current.send(requestInit);
+            }
+            else if (type === 'CHAT_MESSAGE') {
                 setMessages((prevMessages) => {
                     const updatedMessages = [...prevMessages, { nickname: messenger, text: message }];
                     if (updatedMessages.length > MAX_MESSAGES) {
@@ -42,7 +88,7 @@ const useWebSocket = (token) => {
                 const messageInput = document.getElementById('messageInput');
                 messageInput.placeholder = '채팅 입력 불가';
                 setAvailableChat(false);
-            } else if (type === 'INIT') {
+            } else if (type === 'RESPONSE_CHAT_INIT') {
                 console.log('init메시지',message);
                 const initMessages = JSON.parse(message).map(({ init_nickname, init_text }) => ({
                     nickname: init_nickname,
@@ -69,7 +115,7 @@ const useWebSocket = (token) => {
     const sendMessage = (userNickname, message) => {
         if (socket.current && isAvailableChat) {
             socket.current.send(JSON.stringify({
-                type: 'MESSAGE',
+                type: 'CHAT_MESSAGE',
                 messenger: userNickname,
                 message: message
             }));


### PR DESCRIPTION
<br/>

## ✨  제목 : 스트리머페이지 웹소켓을 통한 토큰 재발급 로직 추가


<br/>

## 🔨 작업 내용

- 토큰 재발급 로직 추가

- 리프레쉬 토큰이 유효하지 않으면 Anonymous user로 진행하도록 수정 ( 채팅입력 제외 사용가능)


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 
![image](https://github.com/user-attachments/assets/e20409b4-1524-4488-b3ad-c09016d10b58)


<br/>

## 🔎   앞으로의 과제

- 리팩토링

- 버그 수정 

