### PR TITLE
Fix/#94 방송 종료시 프론트 행동 고침

### DIFF
--- a/src/components/BroadcastControl.jsx
+++ b/src/components/BroadcastControl.jsx
@@ -7,19 +7,16 @@ const BroadcastControl = ({ product, isSettingCompleted, onBroadcastClose }) => 
 
     const [isBroadcastStart, setBroadcastStart] = useState(initialIsBroadcastStart);
     const [title, setTitle] = useState(localStorage.getItem('title') || '');
-    const [code, setCode] = useState(localStorage.getItem('code') || '');
 
     useEffect(() => {
         localStorage.setItem('isBroadcastStart', JSON.stringify(isBroadcastStart));
         localStorage.setItem('title', title);
-        localStorage.setItem('code', code);
-    }, [isBroadcastStart, title, code]);
+    }, [isBroadcastStart, title]);
 
     const handleBroadcastStart = async () => {
         try {
             const response = await axiosInstance.post(`/broadcast`, {
                 "title": title,
-                "code": code,
                 "product_id": product.id
             }, {
                 headers: {
@@ -58,10 +55,6 @@ const BroadcastControl = ({ product, isSettingCompleted, onBroadcastClose }) => 
             <div className={styles.controlItem}>
                 <label>방송 제목</label>
                 <input type="text" placeholder="방송 제목" disabled={!isSettingCompleted || isBroadcastStart} value={title} onChange={(e) => setTitle(e.target.value)} />
-            </div>
-            <div className={styles.controlItem}>
-                <label>방송 코드</label>
-                <input type="text" placeholder="시간별 코드 입력" disabled={!isSettingCompleted || isBroadcastStart} value={code} onChange={(e) => setCode(e.target.value)} />
             </div>
             <div className={styles.buttons}>
                 <button className={styles.startButton} disabled={!isSettingCompleted || isBroadcastStart} onClick={handleBroadcastStart}>방송 시작</button>

--- a/src/components/LiveScreen.jsx
+++ b/src/components/LiveScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import HLSPlayer from '../components/HLSPlayer';
 import useWebSocket from '../hooks/useWebSocket';
 import logo from '../assets/images/stream_logo.png'
@@ -12,12 +12,15 @@ const LiveScreen = () => {
 
     return (
         <div>
-            {wsIsLive ? (
-                <HLSPlayer src={`http://${process.env.REACT_APP_MEDIA_SERVER_ADDRESS}/hls/${wsStreamKey}.m3u8`} />
+            {wsStreamKey != '' ? (
+                <HLSPlayer
+                    src ={`http://${process.env.REACT_APP_MEDIA_SERVER_ADDRESS}/hls/${wsStreamKey}.m3u8`}
+                />
             ) : (
                 <img src={logo} alt="logo"
-                    style={{ width: '730px'}} />
+                    style={{ width: '730px' }} />
             )}
+
         </div>
     );
 };

--- a/src/hooks/useWebSocket.jsx
+++ b/src/hooks/useWebSocket.jsx
@@ -5,8 +5,8 @@ const useWebSocket = (token) => {
     const [messages, setMessages] = useState([]);
     const [isAvailableChat, setAvailableChat] = useState(false);
     const [userNickname, setUserNickname] = useState('');
-    const [wsIsLive, setWsIsLive] = useState(false);
     const [wsStreamKey, setWsStreamKey] = useState('');
+    const [wsIsLive, setWsIsLive] = useState(false);
  
     const MAX_MESSAGES = 100;
 
@@ -108,6 +108,8 @@ const useWebSocket = (token) => {
                 });
             } else if (type === 'BROADCAST') {
                 const broadcastMessage = JSON.parse(message);
+                localStorage.setItem('isBroadcastStart', broadcastMessage.is_live);
+                localStorage.setItem('isSettingCompleted', broadcastMessage.is_live);
                 setWsIsLive(broadcastMessage.is_live);
                 setWsStreamKey(broadcastMessage.stream_key);
             }

--- a/src/styles/BroadcastControl.module.css
+++ b/src/styles/BroadcastControl.module.css
@@ -7,18 +7,16 @@
 }
 
 .controlItem {
-    margin-top: 10px;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
-    margin-bottom: 10px;
+    margin-bottom: 50px;
 }
 
 .controlItem label {
     font-weight: bold;
-    margin-right: 20px;
-    flex: 1;
-    text-align: right;
+    font-size: 2rem;
+    margin-bottom: 20px;
 }
 
 .controlItem input {
@@ -27,7 +25,7 @@
     border: none;
     border-radius: 10px;
     font-size: 1rem;
-    width: 300px;
+    width: 450px;
 }
 
 .buttons {


### PR DESCRIPTION
## ✨  제목 : Fix/#94 방송 종료시 프론트 행동 고침


<br/>

## 🔨 작업 내용

 Fix
  - 방송 종료 되면 스트리머 페이지의 방송 종료 버튼 비활성화
  - 방송 모듈 띄우지 않는 대신 스트림 키만 바꿔줌
  - 더 이상 방송 코드를 입력 받지 않음

  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 디폴트화면
![캡처](https://github.com/user-attachments/assets/b69eb66d-ff1e-44c4-8cc1-3ee5edbc532b)
- 방송 실행 화면(OBS 문제로 까맣게 보이는 거고 실행 중인 거 맞음)
![캡처2](https://github.com/user-attachments/assets/766d8ae1-7687-408d-9f9e-6494429fea0b)


<br/>

## 🔎   앞으로의 과제

- 새로고침 하지 않으면 방송 중단, 방송 시작이 완전히 적용 되지 않는다는 문제가 있음. 새로 고침 하면 정상화 되긴 함. 몇 시간 째 수정을 못 하고 있는데 일단 예약 기능부터 구현 하고 버그 잡는 게 좋을 것 같아서 PR 올립니다. 혹시 고칠 수 있으신 분 도와주세요 ㅠㅠ
  - 중단 시에도 방송 중단 버튼 켜져 있음
  - 방송 시작 시 화면 사라짐

- 

- 


  <br/>

  풀리퀘 후 오른쪽에서 assign, reviewer, label 붙이는거 잊지마세요!!!(중요)
