### PR TITLE
Feature/#106 ten minutes timer

### DIFF
--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -1,0 +1,47 @@
+// Timer.jsx
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+// Timer 컴포넌트 정의
+const Timer = ({ initialTime, onExpire }) => {
+    const [timeLeft, setTimeLeft] = useState(initialTime);
+
+    useEffect(() => {
+        // 타이머 설정
+        const timerId = setInterval(() => {
+            setTimeLeft((prevTime) => {
+                // 시간이 1초 줄어들며 0초가 되면 종료
+                if (prevTime <= 1) {
+                    clearInterval(timerId); // 타이머 종료
+                    onExpire(); // 부모로부터 전달된 만료 처리 함수 호출
+                    return 0;
+                }
+                return prevTime - 1; // 타이머 1초 감소
+            });
+        }, 1000); // 1초마다 실행
+
+        // 컴포넌트 언마운트 시 타이머 정리
+        return () => clearInterval(timerId);
+    }, [onExpire]); // onExpire 함수 변경 시에도 useEffect 재실행
+
+    // 남은 시간을 분:초 형식으로 변환
+    const formatTime = (seconds) => {
+        const minutes = Math.floor(seconds / 60);
+        const secs = seconds % 60;
+        return `${minutes}:${secs < 10 ? '0' : ''}${secs}`; // 초가 한자리 수일 경우 0 추가
+    };
+
+    return (
+        <div className="timer">
+            <p>결제까지 남은 시간: {formatTime(timeLeft)}</p> {/* 남은 시간 표시 */}
+        </div>
+    );
+};
+
+// PropTypes를 사용하여 props 타입 검증
+Timer.propTypes = {
+    initialTime: PropTypes.number.isRequired, // 초기 시간 (초 단위)
+    onExpire: PropTypes.func.isRequired, // 타이머 만료 시 호출할 함수
+};
+
+export default Timer;

--- a/src/pages/StreamingPage.jsx
+++ b/src/pages/StreamingPage.jsx
@@ -74,6 +74,7 @@ function StreamingPage() {
       });
     } catch (error) {
       console.error('재고 확인 실패: ' + (error.response?.data?.message || error.message));
+      alert("남은 재고가 없습니다. 죄송합니다.");
     }
   };
 


### PR DESCRIPTION
<br/>

## ✨  제목 : Feature/#106 ten minutes timer


<br/>

## 🔨 작업 내용

    - 주문 삭제 이후 alert 창 띄우고, Streaming 페이지로 이동시킴
    -  수량 입력 후 완료 버튼을 누른 순간부터 타이머 작동, 10분 후에 백엔드로 주문 삭제 요청 보내기


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 수량을 입력하면 타이머 작동

![image](https://github.com/user-attachments/assets/73ff5ff5-1428-4023-9955-a52a77558c70)

- 타이머가 끝나면 alert 창 나온 후 streaming 페이지로 이동
![image](https://github.com/user-attachments/assets/89b87c6b-f83e-4ca9-b01a-41b4bea4f52c)


<br/>

## 🔎   앞으로의 과제

- 프론트에 시간을 띄워주기 위해 프론트에서 타이머를 돌리기로 했지만, 

 1) 만약 주문을 생성해놓고 창을 꺼버리면 ?
 2) 주문을 생성해놓고 새로고침을 계속 눌러서 시간을 늘리면 ? 

이러한 경우엔 프론트 타이머가 제대로 동작하지 않는다는 점이 문제 입니다 .. 
서버에서 타이머를 돌려야할지... ... 고민되네요.....ㅠ



  <br/>
