### PR TITLE
Fix/#201 deactivation buying product for default broadcast

### DIFF
--- a/src/pages/StreamingPage.jsx
+++ b/src/pages/StreamingPage.jsx
@@ -47,6 +47,10 @@ function StreamingPage() {
   }, [productId, dispatch]);
 
   const handleBuyClick = async (event) => {
+    if(wsIsLive == false) {
+      alert("관리자 기본 방송 중엔 판매중인 상품이 없어서 구매하기 기능 사용이 불가능합니다")
+      return;
+    }
     console.log('product id: ' + productId);
     console.log('broadcast id: ' + broadcastId);
     console.log('product name: ' + productName);


### PR DESCRIPTION
<br/>

## ✨  제목 : Fix/#201 deactivation buying product for default broadcast


<br/>

## 🔨 작업 내용

- 디폴트 방송 중에는 구매하기 버튼 작동 안 하도록 코드 수정

- 버튼 자체를 비활성화 시키는 것보다는 알림을 띄우는 게 나을 거 같아서 그렇게 구현했습니당


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 

<br/>

## 🔎   앞으로의 과제

- 제가 노트북이라 백엔드 세팅이 너무 안 되어있어서 테스트까진 못 해봤는데 간단한 코드라 제대로 작동 할 거 같습니다 코드 한번씩 봐주세용

  <br/>
